### PR TITLE
Use Okta Spring Boot starter with native annotations

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -20,8 +20,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+            <groupId>com.okta.spring</groupId>
+            <artifactId>okta-spring-boot-starter</artifactId>
+            <version>2.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -40,6 +41,7 @@
     </dependencies>
 
     <build>
+        <defaultGoal>spring-boot:run</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -58,6 +60,13 @@
                 <groupId>org.springframework.experimental</groupId>
                 <artifactId>spring-aot-maven-plugin</artifactId>
                 <version>${spring-native.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.okta.spring.boot</groupId>
+                        <artifactId>native-hints</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>test-generate</id>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -60,13 +60,6 @@
                 <groupId>org.springframework.experimental</groupId>
                 <artifactId>spring-aot-maven-plugin</artifactId>
                 <version>${spring-native.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.okta.spring.boot</groupId>
-                        <artifactId>native-hints</artifactId>
-                        <version>0.0.1-SNAPSHOT</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>test-generate</id>

--- a/spring-boot/src/main/java/com/okta/rest/DemoApplication.java
+++ b/spring-boot/src/main/java/com/okta/rest/DemoApplication.java
@@ -2,14 +2,23 @@ package com.okta.rest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.nativex.hint.AccessBits;
 import org.springframework.nativex.hint.NativeHint;
+import org.springframework.nativex.hint.ResourceHint;
+import org.springframework.nativex.hint.TypeHint;
 
 @SpringBootApplication
-@NativeHint(options = "--enable-url-protocols=https")
+/*@NativeHint(options = "--enable-url-protocols=https")
+@ResourceHint(patterns = "com/okta/commons/configcheck/configuration-validator", isBundle = true)
+@TypeHint(typeNames = {
+    "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional",
+    "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$ClientIdCondition",
+    "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$ClientSecretCondition",
+    "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$IntrospectionUriCondition"
+}, access = AccessBits.ALL)*/
 public class DemoApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
     }
-
 }

--- a/spring-boot/src/main/java/com/okta/rest/DemoApplication.java
+++ b/spring-boot/src/main/java/com/okta/rest/DemoApplication.java
@@ -8,14 +8,14 @@ import org.springframework.nativex.hint.ResourceHint;
 import org.springframework.nativex.hint.TypeHint;
 
 @SpringBootApplication
-/*@NativeHint(options = "--enable-url-protocols=https")
+@NativeHint(options = "--enable-url-protocols=https")
 @ResourceHint(patterns = "com/okta/commons/configcheck/configuration-validator", isBundle = true)
 @TypeHint(typeNames = {
     "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional",
     "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$ClientIdCondition",
     "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$ClientSecretCondition",
     "com.okta.spring.boot.oauth.OktaOpaqueTokenIntrospectConditional$IntrospectionUriCondition"
-}, access = AccessBits.ALL)*/
+}, access = AccessBits.ALL)
 public class DemoApplication {
 
     public static void main(String[] args) {

--- a/spring-boot/src/main/resources/application.properties
+++ b/spring-boot/src/main/resources/application.properties
@@ -1,3 +1,1 @@
-#spring.security.oauth2.resourceserver.jwt.issuer-uri=https://dev-1309757.okta.com/oauth2/default
-#spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/certs
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://dev-1309757.okta.com/oauth2/default/v1/keys
+okta.oauth2.issuer=https://dev-1309757.okta.com/oauth2/default


### PR DESCRIPTION
Depends on changes in the Okta Spring Boot Starter https://github.com/okta/okta-spring-boot/pull/311. 

See https://github.com/oktadev/native-java-examples/pull/4 for a version with a native-hints dependency instead.