### PR TITLE
Upgrade version of Helidon

### DIFF
--- a/helidon/pom.xml
+++ b/helidon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.4.1</version>
+        <version>2.4.2</version>
         <relativePath/>
     </parent>
     <groupId>com.okta.rest</groupId>
@@ -35,7 +35,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.jwt</groupId>
+            <artifactId>helidon-microprofile-jwt-auth</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>


### PR DESCRIPTION
Hello Matt,
We have a new Helidon release. It includes several major optimizations.  one of them is the memory issue addressed in your article. Now memory allocation is much less aggressive.

With this PR we:
- Upgrade Helidon to Version 2.4.2
- Optimize overall distribution and memory usage with `microprofile-core`. Thus not all the MicroProfile bundle is loaded, but only the necessary stuff.

Thank you :) 